### PR TITLE
Docker環境でのNext.jsホットリロード最適化

### DIFF
--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -2,6 +2,15 @@
 const nextConfig = {
   reactStrictMode: true,
   swcMinify: true,
+  
+  // Dockerでのホットリロードを最適化
+  webpackDevMiddleware: config => {
+    config.watchOptions = {
+      poll: 1000,
+      aggregateTimeout: 300,
+    }
+    return config
+  },
 };
 
 export default nextConfig; 


### PR DESCRIPTION
macOSではホットリロードが効いていたが、windowsで効いていない問題を解消